### PR TITLE
Corrected `PayFacsSubMerchant` field lengths

### DIFF
--- a/docs/3_Payment/OrderCreation/_acquire-order.mdx
+++ b/docs/3_Payment/OrderCreation/_acquire-order.mdx
@@ -330,25 +330,29 @@ import CardInfo from "./_card-info.mdx";
     - Maximum length: `100`
 
   - **registeredName** <font color='#7d8793'>String</font>  
-    - Registered name of the sub-merchant.
+    - Registered name of the sub-merchant.  
+    - Maximum length: `100`
 
   - **tradingName** <font color='#7d8793'>String</font>  
     - Trading name of the sub-merchant.  
-    - ***Note***: Required when `identifier` has a value.
+    - ***Note***: Required when `identifier` has a value.  
+    - Maximum length: `100`
 
   - **bankIndustryCode** <font color='#7d8793'>String</font>  
     - Bank industry code of the sub-merchant.  
-    - Maximum length: `100`
+    - Maximum length: `4`
 
   - **city** <font color='#7d8793'>String</font>  
-    - City where the sub-merchant is located.
+    - City where the sub-merchant is located.  
+    - Maximum length: `100`
 
   - **country** <font color='#7d8793'>String</font>  
-    - Country where the sub-merchant is located.
+    - Country where the sub-merchant is located.  
+    - Maximum length: `3`
 
   - **phone** <font color='#7d8793'>String</font>  
     - Phone number of the sub-merchant.  
-    - Maximum length: `100`
+    - Maximum length: `20`
 
   - **disputeContactPhone** <font color='#7d8793'>String</font>  
     - Dispute contact phone number of the sub-merchant.  
@@ -356,7 +360,8 @@ import CardInfo from "./_card-info.mdx";
 
   - **marketplaceId** <font color='#7d8793'>String</font>  
     - Marketplace ID of the sub-merchant.  
-    - Maximum length: `100`
+    - Maximum length: `11`
 
   - **governmentCountryCode** <font color='#7d8793'>String</font>  
-    - Country/government code that the sub-merchant belongs to.
+    - Country/government code that the sub-merchant belongs to.  
+    - Maximum length: `3`


### PR DESCRIPTION
### Corrected `PayFacsSubMerchant` field lengths

- Fixed bankIndustryCode (100→4), phone (100→20), marketplaceId (100→11)
- Added missing max lengths for registeredName, tradingName, city,
  country, governmentCountryCode
